### PR TITLE
add support for sepolia + bg chain

### DIFF
--- a/packages/nextjs/components/bgChain/BridgeToBGChain.tsx
+++ b/packages/nextjs/components/bgChain/BridgeToBGChain.tsx
@@ -38,7 +38,7 @@ const BridgeToBGChain = () => {
       setSendValue("");
     } catch (error) {
       const parsedError = getParsedError(error);
-      console.error("⚡️ ~ file: Faucet.tsx:sendETH ~ error", error);
+      console.error("⚡️ ~ file: BridgeToBGChain.tsx:sendETH ~ error", error);
       notification.error(parsedError);
       setLoading(false);
     }

--- a/packages/nextjs/components/bgChain/BridgeToBGChain.tsx
+++ b/packages/nextjs/components/bgChain/BridgeToBGChain.tsx
@@ -1,0 +1,104 @@
+import { useState } from "react";
+import { Address, Balance, InputBase, getParsedError } from "../scaffold-eth";
+import { useConnectModal } from "@rainbow-me/rainbowkit";
+import { parseEther } from "viem";
+import { sepolia, useAccount, useNetwork, useSwitchNetwork, useWalletClient } from "wagmi";
+import { ArrowsRightLeftIcon, BanknotesIcon } from "@heroicons/react/24/outline";
+import { useNetworkColor, useTransactor } from "~~/hooks/scaffold-eth";
+import { bgChainL2 } from "~~/scaffold.config";
+import { notification } from "~~/utils/scaffold-eth";
+
+const BRIDGE_CONTRACT_ADDRESS = "0x729593813494173Ce5d57743692c1E022425765f";
+
+const BridgeToBGChain = () => {
+  const [loading, setLoading] = useState(false);
+  const [sendValue, setSendValue] = useState("");
+  const { address: connectedAddress, isConnected, isConnecting } = useAccount();
+  const { data: walletClient } = useWalletClient();
+  const { chain: connectedChain } = useNetwork();
+  const sepoliaColor = useNetworkColor(sepolia);
+  const { switchNetwork } = useSwitchNetwork();
+  const { openConnectModal } = useConnectModal();
+
+  const bridgeTxn = useTransactor(walletClient);
+
+  const sendETH = async () => {
+    if (!connectedAddress) {
+      return;
+    }
+    try {
+      setLoading(true);
+      await bridgeTxn({
+        to: BRIDGE_CONTRACT_ADDRESS,
+        value: parseEther(sendValue as `${number}`),
+        account: connectedAddress,
+        chain: sepolia,
+      });
+      setLoading(false);
+      setSendValue("");
+    } catch (error) {
+      const parsedError = getParsedError(error);
+      console.error("⚡️ ~ file: Faucet.tsx:sendETH ~ error", error);
+      notification.error(parsedError);
+      setLoading(false);
+    }
+  };
+  return (
+    <div className="bg-base-300 p-6 rounded-xl space-y-4">
+      <h3 className="text-xl font-bold mb-3 text-center">Bridge Sepolia ETH to BG L2 Chain</h3>
+      <div className="space-y-3">
+        <div className="flex flex-col items-center space-y-5">
+          <div className="flex flex-col items-center space-y-2">
+            <span className="text-sm font-bold text-center">Bridge Contract Address</span>
+            <Address address={BRIDGE_CONTRACT_ADDRESS} chain={sepolia} />
+          </div>
+          <div className="flex space-x-4">
+            <div>
+              <span className="text-sm font-bold pl-3">Your SEP ETH Balance:</span>
+              <Balance address={connectedAddress} chain={sepolia} />
+            </div>
+            <div>
+              <span className="text-sm font-bold pl-3">Your BG Chain ETH Balance:</span>
+              <Balance address={connectedAddress} chain={bgChainL2} />
+            </div>
+          </div>
+        </div>
+        <div className="flex flex-col space-y-3">
+          <InputBase placeholder="Amount to bridge" value={sendValue} onChange={value => setSendValue(value)} />
+          {isConnected && connectedChain && connectedChain.id === sepolia.id ? (
+            <button className="h-10 btn btn-secondary btn-sm px-2 rounded-full" onClick={sendETH} disabled={loading}>
+              {!loading ? (
+                <BanknotesIcon className="h-6 w-6" />
+              ) : (
+                <span className="loading loading-spinner loading-sm"></span>
+              )}
+              <span>Send</span>
+            </button>
+          ) : connectedChain ? (
+            <button
+              className="h-10 btn btn-secondary btn-sm px-2 rounded-full"
+              type="button"
+              onClick={() => switchNetwork?.(sepolia.id)}
+            >
+              <ArrowsRightLeftIcon className="h-6 w-4 ml-2 sm:ml-0" />
+              <span className="whitespace-nowrap">
+                Switch to <span style={{ color: sepoliaColor }}>{sepolia.name}</span>
+              </span>
+            </button>
+          ) : (
+            <button
+              onClick={openConnectModal}
+              disabled={isConnecting}
+              className="h-10 btn btn-secondary btn-sm px-2 rounded-full"
+            >
+              {isConnecting && <span className="loading loading-spinner loading-sm"></span>}
+              <span>Connect Wallet</span>
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default BridgeToBGChain;

--- a/packages/nextjs/components/bgChain/BridgeToBGChain.tsx
+++ b/packages/nextjs/components/bgChain/BridgeToBGChain.tsx
@@ -65,7 +65,7 @@ const BridgeToBGChain = () => {
         <div className="flex flex-col space-y-3">
           <InputBase placeholder="Amount to bridge" value={sendValue} onChange={value => setSendValue(value)} />
           {isConnected && connectedChain && connectedChain.id === sepolia.id ? (
-            <button className="h-10 btn btn-secondary btn-sm px-2 rounded-full" onClick={sendETH} disabled={loading}>
+            <button className="h-10 btn btn-accent btn-sm px-2 rounded-full" onClick={sendETH} disabled={loading}>
               {!loading ? (
                 <BanknotesIcon className="h-6 w-6" />
               ) : (
@@ -75,7 +75,7 @@ const BridgeToBGChain = () => {
             </button>
           ) : connectedChain ? (
             <button
-              className="h-10 btn btn-secondary btn-sm px-2 rounded-full"
+              className="h-10 btn btn-accent btn-sm px-2 rounded-full"
               type="button"
               onClick={() => switchNetwork?.(sepolia.id)}
             >
@@ -88,7 +88,7 @@ const BridgeToBGChain = () => {
             <button
               onClick={openConnectModal}
               disabled={isConnecting}
-              className="h-10 btn btn-secondary btn-sm px-2 rounded-full"
+              className="h-10 btn btn-accent btn-sm px-2 rounded-full"
             >
               {isConnecting && <span className="loading loading-spinner loading-sm"></span>}
               <span>Connect Wallet</span>

--- a/packages/nextjs/components/bgChain/BridgeToBGChain.tsx
+++ b/packages/nextjs/components/bgChain/BridgeToBGChain.tsx
@@ -38,7 +38,6 @@ const BridgeToBGChain = () => {
       setSendValue("");
     } catch (error) {
       const parsedError = getParsedError(error);
-      console.error("⚡️ ~ file: BridgeToBGChain.tsx:sendETH ~ error", error);
       notification.error(parsedError);
       setLoading(false);
     }

--- a/packages/nextjs/components/scaffold-eth/Address.tsx
+++ b/packages/nextjs/components/scaffold-eth/Address.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import Blockies from "react-blockies";
 import { CopyToClipboard } from "react-copy-to-clipboard";
 import { isAddress } from "viem";
-import { useEnsAvatar, useEnsName } from "wagmi";
+import { Chain, useEnsAvatar, useEnsName } from "wagmi";
 import { hardhat } from "wagmi/chains";
 import { CheckCircleIcon, DocumentDuplicateIcon } from "@heroicons/react/24/outline";
 import { getBlockExplorerAddressLink, getTargetNetwork } from "~~/utils/scaffold-eth";
@@ -13,6 +13,7 @@ type TAddressProps = {
   disableAddressLink?: boolean;
   format?: "short" | "long";
   size?: "xs" | "sm" | "base" | "lg" | "xl" | "2xl" | "3xl";
+  chain?: Chain;
 };
 
 const blockieSizeMap = {
@@ -28,7 +29,7 @@ const blockieSizeMap = {
 /**
  * Displays an address (or ENS) with a Blockie image and option to copy address.
  */
-export const Address = ({ address, disableAddressLink, format, size = "base" }: TAddressProps) => {
+export const Address = ({ address, disableAddressLink, format, size = "base", chain }: TAddressProps) => {
   const [ens, setEns] = useState<string | null>();
   const [ensAvatar, setEnsAvatar] = useState<string | null>();
   const [addressCopied, setAddressCopied] = useState(false);
@@ -66,7 +67,7 @@ export const Address = ({ address, disableAddressLink, format, size = "base" }: 
     return <span className="text-error">Wrong address</span>;
   }
 
-  const blockExplorerAddressLink = getBlockExplorerAddressLink(getTargetNetwork(), address);
+  const blockExplorerAddressLink = getBlockExplorerAddressLink(chain ? chain : getTargetNetwork(), address);
   let displayAddress = address?.slice(0, 5) + "..." + address?.slice(-4);
 
   if (ens) {

--- a/packages/nextjs/components/scaffold-eth/Balance.tsx
+++ b/packages/nextjs/components/scaffold-eth/Balance.tsx
@@ -1,17 +1,19 @@
+import { Chain } from "wagmi";
 import { useAccountBalance } from "~~/hooks/scaffold-eth";
 import { getTargetNetwork } from "~~/utils/scaffold-eth";
 
 type TBalanceProps = {
   address?: string;
   className?: string;
+  chain?: Chain;
 };
 
 /**
  * Display (ETH & USD) balance of an ETH address.
  */
-export const Balance = ({ address, className = "" }: TBalanceProps) => {
+export const Balance = ({ address, className = "", chain }: TBalanceProps) => {
   const configuredNetwork = getTargetNetwork();
-  const { balance, price, isError, isLoading, onToggleBalance, isEthBalance } = useAccountBalance(address);
+  const { balance, price, isError, isLoading, onToggleBalance, isEthBalance } = useAccountBalance(address, chain);
 
   if (!address || isLoading || balance === null) {
     return (

--- a/packages/nextjs/components/scaffold-eth/Contract/DisplayVariable.tsx
+++ b/packages/nextjs/components/scaffold-eth/Contract/DisplayVariable.tsx
@@ -5,7 +5,7 @@ import { useContractRead } from "wagmi";
 import { ArrowPathIcon } from "@heroicons/react/24/outline";
 import { displayTxResult } from "~~/components/scaffold-eth";
 import { useAnimationConfig } from "~~/hooks/scaffold-eth";
-import { notification } from "~~/utils/scaffold-eth";
+import { getTargetNetwork, notification } from "~~/utils/scaffold-eth";
 
 type DisplayVariableProps = {
   contractAddress: Address;
@@ -22,6 +22,7 @@ export const DisplayVariable = ({ contractAddress, abiFunction, refreshDisplayVa
     address: contractAddress,
     functionName: abiFunction.name,
     abi: [abiFunction] as Abi,
+    chainId: getTargetNetwork().id,
     onError: error => {
       notification.error(error.message);
     },

--- a/packages/nextjs/components/scaffold-eth/Contract/ReadOnlyFunctionForm.tsx
+++ b/packages/nextjs/components/scaffold-eth/Contract/ReadOnlyFunctionForm.tsx
@@ -9,7 +9,7 @@ import {
   getInitialFormState,
   getParsedContractFunctionArgs,
 } from "~~/components/scaffold-eth";
-import { notification } from "~~/utils/scaffold-eth";
+import { getTargetNetwork, notification } from "~~/utils/scaffold-eth";
 
 type TReadOnlyFunctionFormProps = {
   contractAddress: Address;
@@ -25,6 +25,7 @@ export const ReadOnlyFunctionForm = ({ contractAddress, abiFunction }: TReadOnly
     functionName: abiFunction.name,
     abi: [abiFunction] as Abi,
     args: getParsedContractFunctionArgs(form),
+    chainId: getTargetNetwork().id,
     enabled: false,
     onError: (error: any) => {
       notification.error(error.message);

--- a/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton.tsx
+++ b/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { ConnectButton } from "@rainbow-me/rainbowkit";
 import { QRCodeSVG } from "qrcode.react";
 import CopyToClipboard from "react-copy-to-clipboard";
-import { mainnet, useDisconnect, useSwitchNetwork } from "wagmi";
+import { mainnet, sepolia, useDisconnect, useSwitchNetwork } from "wagmi";
 import {
   ArrowLeftOnRectangleIcon,
   ArrowTopRightOnSquareIcon,
@@ -14,6 +14,7 @@ import {
 } from "@heroicons/react/24/outline";
 import { Address, Balance, BlockieAvatar } from "~~/components/scaffold-eth";
 import { useAutoConnect, useNetworkColor } from "~~/hooks/scaffold-eth";
+import { bgChainL2 } from "~~/scaffold.config";
 import { enabledChains } from "~~/services/web3/wagmiConnectors";
 import { getBlockExplorerAddressLink, getTargetNetwork } from "~~/utils/scaffold-eth";
 
@@ -108,6 +109,18 @@ export const RainbowKitCustomConnectButton = () => {
                       tabIndex={0}
                       className="dropdown-content menu z-[2] p-2 mt-2 shadow-center shadow-accent bg-base-200 rounded-box gap-1"
                     >
+                      <li>
+                        <button
+                          className="btn-sm !rounded-xl flex py-3 gap-3"
+                          type="button"
+                          onClick={() => switchNetwork?.(chain.id === sepolia.id ? bgChainL2.id : sepolia.id)}
+                        >
+                          <ArrowsRightLeftIcon className="h-6 w-4 ml-2 sm:ml-0" />
+                          <span className="whitespace-nowrap">
+                            Switch to {chain.id === sepolia.id ? bgChainL2.name : sepolia.name}
+                          </span>
+                        </button>
+                      </li>
                       <li>
                         {addressCopied ? (
                           <div className="btn-sm !rounded-xl flex gap-3 py-3">

--- a/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton.tsx
+++ b/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { ConnectButton } from "@rainbow-me/rainbowkit";
 import { QRCodeSVG } from "qrcode.react";
 import CopyToClipboard from "react-copy-to-clipboard";
-import { useDisconnect, useSwitchNetwork } from "wagmi";
+import { mainnet, useDisconnect, useSwitchNetwork } from "wagmi";
 import {
   ArrowLeftOnRectangleIcon,
   ArrowTopRightOnSquareIcon,
@@ -14,6 +14,7 @@ import {
 } from "@heroicons/react/24/outline";
 import { Address, Balance, BlockieAvatar } from "~~/components/scaffold-eth";
 import { useAutoConnect, useNetworkColor } from "~~/hooks/scaffold-eth";
+import { enabledChains } from "~~/services/web3/wagmiConnectors";
 import { getBlockExplorerAddressLink, getTargetNetwork } from "~~/utils/scaffold-eth";
 
 /**
@@ -22,7 +23,6 @@ import { getBlockExplorerAddressLink, getTargetNetwork } from "~~/utils/scaffold
 export const RainbowKitCustomConnectButton = () => {
   useAutoConnect();
   const networkColor = useNetworkColor();
-  const configuredNetwork = getTargetNetwork();
   const { disconnect } = useDisconnect();
   const { switchNetwork } = useSwitchNetwork();
   const [addressCopied, setAddressCopied] = useState(false);
@@ -46,7 +46,7 @@ export const RainbowKitCustomConnectButton = () => {
                 );
               }
 
-              if (chain.unsupported || chain.id !== configuredNetwork.id) {
+              if (chain.unsupported) {
                 return (
                   <div className="dropdown dropdown-end">
                     <label tabIndex={0} className="btn btn-error btn-sm dropdown-toggle gap-1">
@@ -57,18 +57,22 @@ export const RainbowKitCustomConnectButton = () => {
                       tabIndex={0}
                       className="dropdown-content menu p-2 mt-1 shadow-center shadow-accent bg-base-200 rounded-box gap-1"
                     >
-                      <li>
-                        <button
-                          className="btn-sm !rounded-xl flex py-3 gap-3"
-                          type="button"
-                          onClick={() => switchNetwork?.(configuredNetwork.id)}
-                        >
-                          <ArrowsRightLeftIcon className="h-6 w-4 ml-2 sm:ml-0" />
-                          <span className="whitespace-nowrap">
-                            Switch to <span style={{ color: networkColor }}>{configuredNetwork.name}</span>
-                          </span>
-                        </button>
-                      </li>
+                      {enabledChains
+                        .filter(chain => chain.id !== mainnet.id)
+                        .map(chain => (
+                          <li key={chain.id}>
+                            <button
+                              className="btn-sm !rounded-xl flex py-3 gap-3"
+                              type="button"
+                              onClick={() => switchNetwork?.(chain.id)}
+                            >
+                              <ArrowsRightLeftIcon className="h-6 w-4 ml-2 sm:ml-0" />
+                              <span className="whitespace-nowrap">
+                                Switch to <span style={{ color: networkColor }}>{chain.name}</span>
+                              </span>
+                            </button>
+                          </li>
+                        ))}
                       <li>
                         <button
                           className="menu-item text-error btn-sm !rounded-xl flex gap-3 py-3"

--- a/packages/nextjs/hooks/scaffold-eth/useAccountBalance.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useAccountBalance.ts
@@ -1,9 +1,8 @@
 import { useCallback, useEffect, useState } from "react";
-import { useBalance } from "wagmi";
+import { Chain, useBalance } from "wagmi";
 import { useGlobalState } from "~~/services/store/store";
-import { getTargetNetwork } from "~~/utils/scaffold-eth";
 
-export function useAccountBalance(address?: string) {
+export function useAccountBalance(address?: string, chain?: Chain) {
   const [isEthBalance, setIsEthBalance] = useState(true);
   const [balance, setBalance] = useState<number | null>(null);
   const price = useGlobalState(state => state.nativeCurrencyPrice);
@@ -15,7 +14,8 @@ export function useAccountBalance(address?: string) {
   } = useBalance({
     address,
     watch: true,
-    chainId: getTargetNetwork().id,
+    // undefined meaning use fetch the balance of user connected chain
+    chainId: chain ? chain.id : undefined,
   });
 
   const onToggleBalance = useCallback(() => {

--- a/packages/nextjs/hooks/scaffold-eth/useNetworkColor.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useNetworkColor.ts
@@ -1,14 +1,18 @@
 import { useDarkMode } from "usehooks-ts";
-import { getTargetNetwork } from "~~/utils/scaffold-eth";
+import { Chain } from "wagmi";
+import { NETWORKS_EXTRA_DATA, getTargetNetwork } from "~~/utils/scaffold-eth";
 
 const DEFAULT_NETWORK_COLOR: [string, string] = ["#666666", "#bbbbbb"];
 
 /**
  * Gets the color of the target network
  */
-export const useNetworkColor = () => {
+export const useNetworkColor = (chain?: Chain) => {
   const { isDarkMode } = useDarkMode();
-  const colorConfig = getTargetNetwork().color ?? DEFAULT_NETWORK_COLOR;
+  const colorConfig =
+    chain && NETWORKS_EXTRA_DATA[chain.id]?.color
+      ? NETWORKS_EXTRA_DATA[chain.id].color
+      : getTargetNetwork().color ?? DEFAULT_NETWORK_COLOR;
 
   return Array.isArray(colorConfig) ? (isDarkMode ? colorConfig[1] : colorConfig[0]) : colorConfig;
 };

--- a/packages/nextjs/hooks/scaffold-eth/useTransactor.tsx
+++ b/packages/nextjs/hooks/scaffold-eth/useTransactor.tsx
@@ -1,6 +1,7 @@
 import { WriteContractResult, getPublicClient } from "@wagmi/core";
 import { Hash, SendTransactionParameters, TransactionReceipt, WalletClient } from "viem";
 import { useWalletClient } from "wagmi";
+import { GetWalletClientResult } from "wagmi/actions";
 import { getParsedError } from "~~/components/scaffold-eth";
 import { getBlockExplorerTxLink, notification } from "~~/utils/scaffold-eth";
 
@@ -33,7 +34,7 @@ const TxnNotification = ({ message, blockExplorerLink }: { message: string; bloc
  * @param _walletClient
  * @returns function that takes a transaction and returns a promise of the transaction hash
  */
-export const useTransactor = (_walletClient?: WalletClient): TransactionFunc => {
+export const useTransactor = (_walletClient?: GetWalletClientResult | WalletClient): TransactionFunc => {
   let walletClient = _walletClient;
   const { data } = useWalletClient();
   if (walletClient === undefined && data) {

--- a/packages/nextjs/pages/_app.tsx
+++ b/packages/nextjs/pages/_app.tsx
@@ -5,7 +5,7 @@ import "@rainbow-me/rainbowkit/styles.css";
 import NextNProgress from "nextjs-progressbar";
 import { Toaster } from "react-hot-toast";
 import { useDarkMode } from "usehooks-ts";
-import { WagmiConfig } from "wagmi";
+import { WagmiConfig, sepolia } from "wagmi";
 import { Footer } from "~~/components/Footer";
 import { Header } from "~~/components/Header";
 import { BlockieAvatar } from "~~/components/scaffold-eth";
@@ -39,6 +39,8 @@ const ScaffoldEthApp = ({ Component, pageProps }: AppProps) => {
         chains={appChains.chains}
         avatar={BlockieAvatar}
         theme={isDarkTheme ? darkTheme() : lightTheme()}
+        // Settting to sepolia since inittaly people want to directly bridge to BG Chain
+        initialChain={sepolia}
       >
         <div className="flex flex-col min-h-screen">
           <Header />

--- a/packages/nextjs/pages/index.tsx
+++ b/packages/nextjs/pages/index.tsx
@@ -1,5 +1,6 @@
 import type { NextPage } from "next";
 import { MetaHeader } from "~~/components/MetaHeader";
+import BridgeToBGChain from "~~/components/bgChain/BridgeToBGChain";
 
 const Home: NextPage = () => {
   return (
@@ -11,6 +12,7 @@ const Home: NextPage = () => {
             <span className="block text-4xl font-bold">BuidlGuidl L2</span>
           </h1>
           <p className="text-center text-lg">L2 Tesnet (powered by the OP stack) for the BuidlGuidl.</p>
+          <BridgeToBGChain />
         </div>
       </div>
     </>

--- a/packages/nextjs/scaffold.config.ts
+++ b/packages/nextjs/scaffold.config.ts
@@ -24,6 +24,10 @@ export const bgChainL2 = {
     public: { http: ["https://rpc.l2.buidlguidl.com"] },
     default: { http: ["https://rpc.l2.buidlguidl.com"] },
   },
+  blockExplorers: {
+    etherscan: { name: "BG L2 Explorer", url: "https://explorer.l2.buidlguidl.com" },
+    default: { name: "BG L2 Explorer", url: "https://explorer.l2.buidlguidl.com" },
+  },
 } as const satisfies Chain;
 
 const scaffoldConfig = {

--- a/packages/nextjs/services/web3/wagmiConnectors.tsx
+++ b/packages/nextjs/services/web3/wagmiConnectors.tsx
@@ -19,7 +19,7 @@ const configuredNetwork = getTargetNetwork();
 const { onlyLocalBurnerWallet } = scaffoldConfig;
 
 // We always want to have mainnet enabled (ENS resolution, ETH price, etc). But only once.
-const enabledChains = configuredNetwork.id === 1 ? [configuredNetwork] : [configuredNetwork, chains.mainnet];
+export const enabledChains = [configuredNetwork, chains.sepolia, chains.mainnet];
 
 /**
  * Chains for the app


### PR DESCRIPTION
## Description


https://github.com/BuidlGuidl/l2.buidlguidl.com/assets/80153681/2d3efcd6-3fe4-4032-9952-22d1d93e0288

Tried adding support for both chains, tried keeping things generic instead of hardcoding it was mostly adding extra `chain : Chain` prop/args to different components / utilities 

Now we can use normal Wagmi hooks for sending / writing and making sure we pass in `chainId` and everything should fine work and react to the passed chain 🙌

---

Regarding this comment in `scaffold.config.ts` : 

https://github.com/BuidlGuidl/l2.buidlguidl.com/blob/c628621c3efb6267627b17efc569c5774d7fc105/packages/nextjs/scaffold.config.ts#L13

**I think** :  the reason it's  becoming `undefined` and breaking the whole app is because of circular dependencies : 

If we have `bgChain` in `network.ts` 

```ts
// network.ts
import scaffoldConfig from "~~/scaffold.config"; <-----------------------

export const bgChain = {...}

export function getTargetNetwork(): chains.Chain & Partial<TChainAttributes> {
  const configuredNetwork = scaffoldConfig.targetNetwork;
  ...
 }
 
 // ------------
 
 // scaffold.config.ts
 
 import { bgChainL2 } from "./utils/scaffold-eth/networks"; <-----------------------
 ....
 
```

I think because of this we form circular dependency : 

1. `scaffold.config` depends on `networks.ts` for `bgChain`
2. `networks` depends on `scaffold.config` for `scaffold. config.targetNetwork`

I tried moving `bgChain` to a different location and importing from there and everything worked fine. Lol but I was confused where to best move it other than `networks.ts` so kept it as it is in scaffold.config  

